### PR TITLE
Add building instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ docker exec darling1 shell -c 'uname -a'
 
 ## Advanced
 
+### Building
+
+You need to specify an URL that points to Darling's DEB file like this:
+
+```
+docker build --build-arg DARLING_DEB='http://172.17.0.1:7000/dist/darling_0.1.20210517~focal_amd64.deb' .
+```
+
+The latest experimental DEB file can be obtained from [darlinghq/darling 's build artifacts](https://github.com/darlinghq/darling/actions).
+
 ### Experimental X11
 
 First of all, disable authorization on your X11 session by executing `xhost +`. Keeping the authorization enabled [is trickier](https://stackoverflow.com/a/25280523/479753).


### PR DESCRIPTION
In addition to this PR, I'd like to make an additional suggestion:

Update darlinghq/darling 's Github Actions config so that the latest DEB files are each individual artifacts. This way no unzipping the "deb" artifact is required. Then it would be possible to use https://nightly.link/ to point the Docker `DARLING_DEB` build arg directly to the single-deb-file artifact. This would make for a much easier building process for the Docker image.